### PR TITLE
Change Report reference column on table Rounds to allow null values

### DIFF
--- a/db/migrate/20241221023018_change_round_column_report_to_allow_null.rb
+++ b/db/migrate/20241221023018_change_round_column_report_to_allow_null.rb
@@ -1,0 +1,5 @@
+class ChangeRoundColumnReportToAllowNull < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :rounds, :report_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_18_195846) do
+ActiveRecord::Schema[7.2].define(version: 2024_12_21_023018) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -87,7 +87,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_18_195846) do
     t.integer "round_time"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "report_id", null: false
+    t.bigint "report_id"
     t.index ["collection_id"], name: "index_rounds_on_collection_id"
     t.index ["current_equation_id"], name: "index_rounds_on_current_equation_id"
     t.index ["report_id"], name: "index_rounds_on_report_id"


### PR DESCRIPTION
This PR addresses an issue where the report needs to be created before the round. With this change, the report can now be created at the end of the round, making more sense in the context of the application flow.

Changes:
- Updated Round model to allow null report reference

The application flow to create the report at the end of the round will be revised at #16 